### PR TITLE
Use Equals to compare facet values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0]
+### Changed
+* Requires Examine 1.1.0+
+* Sorting and paging is now handled by Examine
+
+### Removed
+* `FacetSearchResultsBase` has been replaced by Examine 1.1.0
+
 ## [1.0.0] - 2020-08-12
 ### Added
 * Initial release of Examine Facets
@@ -11,4 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 * Support for MultiFacetsLucene.Net
 * Documentation for configuration and querying
 
-[Unreleased]: https://github.com/callumbwhyte/examine-facets/compare/release-1.0.0...HEAD
+[Unreleased]: https://github.com/callumbwhyte/examine-facets/compare/release-1.1.0...HEAD
+[1.1.0]: https://github.com/callumbwhyte/examine-facets/tree/release-1.1.0
+[1.0.0]: https://github.com/callumbwhyte/examine-facets/tree/release-1.0.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Powerful filtering and faceting directly within the [Examine](https://github.com
 
 ## Getting started
 
-This package requires [Examine](https://github.com/shazwazza/examine) 1.0.3+.
+This package requires [Examine](https://github.com/shazwazza/examine) 1.1.0+.
 
 ### Installation
 

--- a/src/Examine.Facets/FacetResult.cs
+++ b/src/Examine.Facets/FacetResult.cs
@@ -13,27 +13,11 @@ namespace Examine.Facets
             _values = values;
         }
 
-        ///<inheritdoc/>
-        public int GetHits(object value)
-        {
-            var facet = _values.FirstOrDefault(x => x.Value == value);
+		///<inheritdoc/>
+		public int GetHits(object value) => _values.FirstOrDefault(x => Equals(x.Value, value))?.Hits ?? 0;
 
-            if (facet == null)
-            {
-                return 0;
-            }
+		public IEnumerator<IFacetValue> GetEnumerator() => _values.GetEnumerator();
 
-            return facet.Hits;
-        }
-
-        public IEnumerator<IFacetValue> GetEnumerator()
-        {
-            return _values.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
-    }
+		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+	}
 }

--- a/src/Examine.Facets/LuceneEngine/FacetSearchQuery.cs
+++ b/src/Examine.Facets/LuceneEngine/FacetSearchQuery.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Generic;
-using Examine.Facets.Search;
+﻿using Examine.Facets.Search;
 using Examine.LuceneEngine.Search;
 using Examine.Search;
 using Lucene.Net.Analysis;
-using Lucene.Net.Search;
 
 namespace Examine.Facets.LuceneEngine
 {
@@ -12,16 +10,10 @@ namespace Examine.Facets.LuceneEngine
     /// </summary>
     public abstract class FacetSearchQuery : LuceneSearchQuery, IFacetQuery
     {
-        private readonly ISearchContext _searchContext;
-
-        public List<SortField> SortFields { get; }
-
         public FacetSearchQuery(ISearchContext searchContext, string category, Analyzer analyzer, string[] fields, LuceneSearchOptions searchOptions, BooleanOperation occurance)
             : base(searchContext, category, analyzer, fields, searchOptions, occurance)
         {
-            _searchContext = searchContext;
 
-            SortFields = new List<SortField>();
         }
 
         ///<inheritdoc/>
@@ -47,75 +39,6 @@ namespace Examine.Facets.LuceneEngine
         /// Register <see cref="IFacetField"/> for use within query
         /// </summary>
         protected abstract void FacetInternal(IFacetField field);
-
-        ///<inheritdoc/>
-        public new IBooleanOperation OrderBy(params SortableField[] fields)
-        {
-            OrderByInternal(false, fields);
-
-            return base.OrderBy(fields);
-        }
-
-        ///<inheritdoc/>
-        public new IBooleanOperation OrderByDescending(params SortableField[] fields)
-        {
-            OrderByInternal(true, fields);
-
-            return base.OrderBy(fields);
-        }
-
-        /// <summary>
-        /// Register <see cref="SortableField"/> for use within query
-        /// </summary>
-        protected virtual void OrderByInternal(bool descending, params SortableField[] fields)
-        {
-            foreach (var field in fields)
-            {
-                var defaultSort = SortField.STRING;
-
-                switch (field.SortType)
-                {
-                    case SortType.Score:
-                        defaultSort = SortField.SCORE;
-                        break;
-                    case SortType.DocumentOrder:
-                        defaultSort = SortField.DOC;
-                        break;
-                    case SortType.String:
-                        defaultSort = SortField.STRING;
-                        break;
-                    case SortType.Int:
-                        defaultSort = SortField.INT;
-                        break;
-                    case SortType.Float:
-                        defaultSort = SortField.FLOAT;
-                        break;
-                    case SortType.Long:
-                        defaultSort = SortField.LONG;
-                        break;
-                    case SortType.Double:
-                        defaultSort = SortField.DOUBLE;
-                        break;
-                    case SortType.Short:
-                        defaultSort = SortField.SHORT;
-                        break;
-                    case SortType.Byte:
-                        defaultSort = SortField.BYTE;
-                        break;
-                }
-
-                var fieldName = field.FieldName;
-
-                var valueType = _searchContext.GetFieldValueType(fieldName);
-
-                if (valueType?.SortableFieldName != null)
-                {
-                    fieldName = valueType.SortableFieldName;
-                }
-
-                SortFields.Add(new SortField(fieldName, defaultSort, descending));
-            }
-        }
 
         protected override LuceneBooleanOperationBase CreateOp() => new FacetBooleanOperation(this);
 


### PR DESCRIPTION
This fixes https://github.com/callumbwhyte/examine-facets/issues/1 by using `Equals()` instead of the `==` operator (that uses `ReferenceEquals()`) when getting the hits for a facet value.