### PR TITLE
Call Execute on query

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ query.And()
 Facet searches behave the same as any other Examine search. To retreive information about facets there are some handy extension methods.
 
 ```
-var results = searcher.Execute();
+var results = query.Execute();
 ```
 
 To get a list of all facets:


### PR DESCRIPTION
It seems this is a typo:

```
var results = searcher.Execute();
```

it should be this instead:

```
var results = query.Execute();
```